### PR TITLE
Use stop() method on MessageHandlingServer

### DIFF
--- a/neutron/service.py
+++ b/neutron/service.py
@@ -129,7 +129,7 @@ class RpcWorker(object):
     def stop(self):
         for server in self._servers:
             if isinstance(server, rpc_server.MessageHandlingServer):
-                server.kill()
+                server.stop()
             self._servers = []
 
 


### PR DESCRIPTION
MessageHandlingServer has no kill() method. In case neutron server using
rpc workers and is stopped, wrong method is called.

Change-Id: Id4a11f3dca070e684fb9e079139ac09792bc7aad
Closes-Bug: 1387053
(cherry picked from commit 42f4c8d0e693a7ef8b058111f5e1bf1ecc618620)
(cherry picked from commit 66a91ddd601f5d2644af7bf82cd23cfe6dcd4322)
Signed-off-by: huntxu mhuntxu@gmail.com
