### PR TITLE
Implement firewall target routers

### DIFF
--- a/neutron/db/firewall/targetrouters_db.py
+++ b/neutron/db/firewall/targetrouters_db.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2015 Eayun, Inc.
+# All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import sqlalchemy as sa
+from sqlalchemy import orm
+from sqlalchemy.orm import exc
+
+from neutron.db import common_db_mixin as base_db
+from neutron.db import model_base
+from neutron.db import l3_db
+from neutron.db.firewall import firewall_db
+from neutron.extensions.firewall import FIREWALLS
+from neutron.extensions import firewall_target_routers as fw_tr_ext
+from neutron.openstack.common import log as logging
+
+LOG = logging.getLogger(__name__)
+
+
+class FirewallRouterBinding(model_base.BASEV2):
+    firewall_id = sa.Column(sa.String(36),
+                            sa.ForeignKey('firewalls.id', ondelete='CASCADE'),
+                            primary_key=True)
+    router_id = sa.Column(sa.String(36),
+                          sa.ForeignKey('routers.id', ondelete='CASCADE'),
+                          primary_key=True)
+    firewalls = orm.relationship(
+        firewall_db.Firewall,
+        backref=orm.backref(fw_tr_ext.FW_TARGET_ROUTERS,
+                            lazy='joined', cascade='delete'))
+
+
+class FirewallTargetRoutersMixin(base_db.CommonDbMixin):
+    """Mixin class for firewall target routers."""
+
+    def _extend_firewall_dict_target_routers(self, firewall_res, firewall_db):
+        fw_target_routers = [
+            binding.router_id for binding
+            in firewall_db[fw_tr_ext.FW_TARGET_ROUTERS]]
+        firewall_res[fw_tr_ext.FW_TARGET_ROUTERS] = fw_target_routers
+        return firewall_res
+
+    firewall_db.Firewall_db_mixin.register_dict_extend_funcs(
+        FIREWALLS, ['_extend_firewall_dict_target_routers'])
+
+    def check_router_in_use(self, context, router_id):
+        mq = self._model_query(context, FirewallRouterBinding)
+        firewalls = [
+            binding.firewall_id for binding
+            in mq.filter_by(router_id=router_id)
+        ]
+        if firewalls:
+            raise fw_tr_ext.RouterInUseByFirewall(
+                router_id=router_id,
+                firewalls=firewalls)
+
+    def _process_create_firewall_target_routers(self, context,
+                                                firewall_id, router_ids):
+        with context.session.begin(subtransactions=True):
+            for router_id in router_ids:
+                try:
+                    self._get_by_id(context, l3_db.Router, router_id)
+                except exc.NoResultFound:
+                    LOG.warn(_('Router %s cannot be found'), router_id)
+                    continue
+                firewall_router_binding_db = FirewallRouterBinding(
+                    firewall_id=firewall_id,
+                    router_id=router_id)
+                context.session.add(firewall_router_binding_db)
+
+    def _get_target_routers(self, context, firewall_id):
+        mq = self._model_query(context, FirewallRouterBinding)
+        return [db.router_id for db in mq.filter_by(firewall_id=firewall_id)]
+
+    def _delete_target_routers(self, context, firewall_id):
+        mq = self._model_query(context, FirewallRouterBinding)
+        with context.session.begin(subtransactions=True):
+            mq.filter(
+                FirewallRouterBinding.firewall_id == firewall_id
+            ).delete()

--- a/neutron/db/l3_db.py
+++ b/neutron/db/l3_db.py
@@ -429,6 +429,11 @@ class L3_NAT_dbonly_mixin(l3.RouterPluginBase):
             if vpnservice:
                 vpnservice.check_router_in_use(context, id)
 
+            fwservice = manager.NeutronManager.get_service_plugins().get(
+                constants.FIREWALL)
+            if fwservice:
+                fwservice.check_router_in_use(context, id)
+
             router_ports = router.attached_ports.all()
             # Set the router's gw_port to None to avoid a constraint violation.
             router.gw_port = None

--- a/neutron/db/migration/alembic_migrations/eayun_fw_target_router_init_ops.py
+++ b/neutron/db/migration/alembic_migrations/eayun_fw_target_router_init_ops.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2015 Eayun, Inc.
+# All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table(
+        'firewallrouterbindings',
+        sa.Column('firewall_id', sa.String(length=36), nullable=False),
+        sa.Column('router_id', sa.String(length=36), nullable=False),
+        sa.ForeignKeyConstraint(['router_id'], ['routers.id'],
+                                ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['firewall_id'], ['firewalls.id'],
+                                ondelete='CASCADE'),
+    )
+
+
+def downgrade():
+    op.drop_table('firewallrouterbindings')

--- a/neutron/db/migration/alembic_migrations/versions/HEAD
+++ b/neutron/db/migration/alembic_migrations/versions/HEAD
@@ -1,1 +1,1 @@
-eayun_portmapping
+eayun_fw_target_router

--- a/neutron/db/migration/alembic_migrations/versions/eayun_fw_target_router.py
+++ b/neutron/db/migration/alembic_migrations/versions/eayun_fw_target_router.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2015 Eayun, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
+"""eayun_fw_target_router
+
+Revision ID: eayun_fw_target_router
+Revises: eayun_neutron_qos
+Create Date: 2015-08-19 14:00:00.000000
+
+"""
+from neutron.db.migration.alembic_migrations import (
+    eayun_fw_target_router_init_ops
+)
+
+
+# revision identifiers, used by Alembic.
+revision = 'eayun_fw_target_router'
+down_revision = 'eayun_neutron_qos'
+
+
+def upgrade():
+    eayun_fw_target_router_init_ops.upgrade()
+
+
+def downgrade():
+    eayun_fw_target_router_init_ops.downgrade()

--- a/neutron/extensions/firewall.py
+++ b/neutron/extensions/firewall.py
@@ -211,6 +211,7 @@ def _validate_ip_or_subnet_or_none(data, valid_values=None):
 attr.validators['type:port_range'] = _validate_port_range
 attr.validators['type:ip_or_subnet_or_none'] = _validate_ip_or_subnet_or_none
 
+FIREWALLS = 'firewalls'
 
 RESOURCE_ATTRIBUTE_MAP = {
     'firewall_rules': {

--- a/neutron/extensions/firewall_target_routers.py
+++ b/neutron/extensions/firewall_target_routers.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2015 Eayun, Inc.
+# All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+from neutron.api import extensions
+from neutron.api.v2 import attributes as attr
+from neutron.common import exceptions as nexception
+from neutron.extensions.firewall import FIREWALLS
+
+FW_TARGET_ROUTERS = 'fw_target_routers'
+
+
+class RouterInUseByFirewall(nexception.InUse):
+    message = _("Router %(router_id)s is used by firewalls: %(firewalls)s")
+
+
+EXTENDED_ATTRIBUTES_2_0 = {
+    FIREWALLS: {
+        FW_TARGET_ROUTERS: {'allow_post': True, 'allow_put': True,
+                            'validate': {'type:uuid_list': None},
+                            'convert_to': attr.convert_none_to_empty_list,
+                            'default': attr.ATTR_NOT_SPECIFIED,
+                            'is_visible': True},
+    }
+}
+
+
+class Firewall_target_routers(extensions.ExtensionDescriptor):
+    """Extension class supporting firewall target routers."""
+
+    @classmethod
+    def get_name(cls):
+        return "Firewall Target Routers"
+
+    @classmethod
+    def get_alias(cls):
+        return "firewall-target-routers"
+
+    @classmethod
+    def get_description(cls):
+        return "Allow specifying target routers for firewalls"
+
+    @classmethod
+    def get_namespace(cls):
+        return "https://github.com/eayunstack"
+
+    @classmethod
+    def get_updated(cls):
+        return "2015-08-18T12:00:00-00:00"
+
+    def get_extended_resources(self, version):
+        if version == "2.0":
+            return EXTENDED_ATTRIBUTES_2_0
+        else:
+            return {}


### PR DESCRIPTION
This patch allows users to specify which router(s) the firewall should
be bound to, making the usage of FWaaS more flexible.

Usage:
- to bind the firewall to the specified router(s) or update the
  bindings:
  - neutron firewall-create/update ... --fw_target_routers list=true \
    router_id1, router_id2
- to clear the bindings (i.e., make the firewall active on all routers
  of the tenant):
  - neutron firewall-update ... --fw_target_routers action=clear

Fixes: redmine #4674

Signed-off-by: huntxu mhuntxu@gmail.com
