### PR TITLE
Metering iptables: make packets travel through metering chain earlier

### DIFF
--- a/neutron/services/metering/drivers/iptables/iptables_driver.py
+++ b/neutron/services/metering/drivers/iptables/iptables_driver.py
@@ -30,7 +30,7 @@ LOG = logging.getLogger(__name__)
 NS_PREFIX = 'qrouter-'
 WRAP_NAME = 'neutron-meter'
 EXTERNAL_DEV_PREFIX = 'qg-'
-TOP_CHAIN = WRAP_NAME + "-FORWARD"
+TOP_CHAIN = WRAP_NAME + "-local"
 RULE = '-r-'
 LABEL = '-l-'
 


### PR DESCRIPTION
neutron-meter-FORWARD is NOT guaranteed to be travelled through before
neutron-l3-agent-FORWARD. Thus, when there are FWaaS rules packets may
not be counted because they have been already accepted and will not
continue traversing the neutron-meter-FORWARD chain.

Fixes: redmine #6468

Signed-off-by: huntxu mhuntxu@gmail.com
