### PR TITLE
Pass '--dhcp-authoritative' option to dnsmasq

### DIFF
--- a/neutron/agent/linux/dhcp.py
+++ b/neutron/agent/linux/dhcp.py
@@ -366,6 +366,7 @@ class Dnsmasq(DhcpLocalProcess):
             '--addn-hosts=%s' % self._output_addn_hosts_file(),
             '--dhcp-optsfile=%s' % self._output_opts_file(),
             '--leasefile-ro',
+            '--dhcp-authoritative',
         ]
 
         possible_leases = 0

--- a/neutron/tests/unit/test_linux_dhcp.py
+++ b/neutron/tests/unit/test_linux_dhcp.py
@@ -753,7 +753,8 @@ class TestDnsmasq(TestBase):
             '--dhcp-hostsfile=/dhcp/%s/host' % network.id,
             '--addn-hosts=/dhcp/%s/addn_hosts' % network.id,
             '--dhcp-optsfile=/dhcp/%s/opts' % network.id,
-            '--leasefile-ro']
+            '--leasefile-ro',
+            '--dhcp-authoritative']
 
         seconds = ''
         if lease_duration == -1:


### PR DESCRIPTION
When dnsmasq is restarted, it forgets about all leases (since it runs
with leasefile-ro option). When client tries to renew its lease, dnsmasq
sends DHCPNAK reply with message "lease not found". Then client shuts
down the network and re-request lease from DHCP server (and gets exactly
same IP address). There's a small network downtime which affects
services, like zookeeper, running in VMs.

Change-Id: Ieff0236670c1403b5d79ad8e50d7574c1b694e34
Closes-Bug: #1345947
Co-Authored-By: Kevin Bringard kevinbri@cisco.com
(cherry picked from commit 74a16fde1c9972dc3c5d07215ca9d5e8f2e23d70)
(cherry picked from commit ed799e38fe740621776aab51c95ec1db248af997)
Signed-off-by: Hunt Xu mhuntxu@gmail.com
