### PR TITLE
metering: fix minor error in agent

### DIFF
--- a/neutron/services/metering/agents/metering_agent.py
+++ b/neutron/services/metering/agents/metering_agent.py
@@ -188,7 +188,8 @@ class MeteringAgent(MeteringPluginRpc, manager.Manager):
         routers = self._get_sync_data_metering(self.context)
 
         routers_on_agent = set(self.routers.keys())
-        routers_on_server = set([router['id'] for router in routers])
+        routers_on_server = set([router['id'] for router in routers]
+                                if routers else [])
 
         for router_id in routers_on_agent - routers_on_server:
             del self.routers[router_id]


### PR DESCRIPTION
When syncing data from the server, server may return None.

Fixes: redmine #7375

Signed-off-by: Hunt Xu mhuntxu@gmail.com
