### PR TITLE
VPNaaS: make dpd_action input validation work

### DIFF
--- a/neutron/extensions/vpnaas.py
+++ b/neutron/extensions/vpnaas.py
@@ -204,7 +204,7 @@ RESOURCE_ATTRIBUTE_MAP = {
                 'default': {},
                 'validate': {
                     'type:dict_or_empty': {
-                        'actions': {
+                        'action': {
                             'type:values': vpn_dpd_supported_actions,
                         },
                         'interval': {


### PR DESCRIPTION
Fix a typo which causes the validation of dpd action is never performed.

Fixes: redmine #8878

Signed-off-by: Hunt Xu <mhuntxu@gmail.com>