### PR TITLE
Fix ipset can't be destroyed when last rule is deleted

### DIFF
--- a/neutron/db/securitygroups_rpc_base.py
+++ b/neutron/db/securitygroups_rpc_base.py
@@ -192,6 +192,11 @@ class SecurityGroupServerRpcMixin(sg_db.SecurityGroupDbMixin):
             if rule_dict not in sg_info['security_groups'][security_group_id]:
                 sg_info['security_groups'][security_group_id].append(
                     rule_dict)
+        # Update the security groups info if they don't have any rules
+        sg_ids = self._select_sg_ids_for_ports(context, ports)
+        for (sg_id, ) in sg_ids:
+            if sg_id not in sg_info['security_groups']:
+                sg_info['security_groups'][sg_id] = []
 
         sg_info['sg_member_ips'] = remote_security_group_info
         # the provider rules do not belong to any security group, so these
@@ -210,6 +215,15 @@ class SecurityGroupServerRpcMixin(sg_db.SecurityGroupDbMixin):
                     and ip not in sg_info['sg_member_ips'][sg_id][ethertype]):
                     sg_info['sg_member_ips'][sg_id][ethertype].append(ip)
         return sg_info
+
+    def _select_sg_ids_for_ports(self, context, ports):
+        if not ports:
+            return []
+        sg_binding_port = sg_db.SecurityGroupPortBinding.port_id
+        sg_binding_sgid = sg_db.SecurityGroupPortBinding.security_group_id
+        query = context.session.query(sg_binding_sgid)
+        query = query.filter(sg_binding_port.in_(ports.keys()))
+        return query.all()
 
     def _select_rules_for_ports(self, context, ports):
         if not ports:


### PR DESCRIPTION
when it deletes a security group all rules, it should
include this sg information in RPC method
'security_group_info_for_devices', otherwise the ports
in this sg can't corrcectly update their iptables and
ipset sets.

Change-Id: Ibb071ce84590bd46cda2c1e010a566e75e22b4d2
Closes-bug: #1460562

Fixes: redmine #8916