### PR TITLE
iptables_firewall: use ipset to track private addresses when enabled

### DIFF
--- a/etc/neutron/plugins/ml2/ml2_conf.ini
+++ b/etc/neutron/plugins/ml2/ml2_conf.ini
@@ -69,3 +69,6 @@
 # Use ipset to speed-up the iptables security groups. Enabling ipset support
 # requires that ipset is installed on L2 agent node.
 # enable_ipset = True
+
+# IP addresses that should be recognized as private.
+# private_nets = 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.0.0/16

--- a/neutron/agent/linux/ipset_manager.py
+++ b/neutron/agent/linux/ipset_manager.py
@@ -24,8 +24,8 @@ class IpsetManager(object):
         self.namespace = namespace
 
     @utils.synchronized('ipset', external=True)
-    def create_ipset_chain(self, chain_name, ethertype):
-        cmd = ['ipset', 'create', '-exist', chain_name, 'hash:ip', 'family',
+    def create_ipset_chain(self, chain_name, ethertype, typename='hash:ip'):
+        cmd = ['ipset', 'create', '-exist', chain_name, typename, 'family',
                self._get_ipset_chain_type(ethertype)]
         self._apply(cmd)
 

--- a/neutron/agent/securitygroups_rpc.py
+++ b/neutron/agent/securitygroups_rpc.py
@@ -41,7 +41,14 @@ security_group_opts = [
     cfg.BoolOpt(
         'enable_ipset',
         default=True,
-        help=_('Use ipset to speed-up the iptables based security groups.'))
+        help=_('Use ipset to speed-up the iptables based security groups.')),
+    cfg.ListOpt(
+        'private_nets',
+        default=[
+            '10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16',  # RFC 1918
+            '169.254.0.0/16'  # RFC 3927
+        ],
+        help=_('IP addresses that should be recognized as private.'))
 ]
 cfg.CONF.register_opts(security_group_opts, 'SECURITYGROUP')
 


### PR DESCRIPTION
This commit also adds the support for setting such addresses/networks
via neutron's configurations.

Fixes: redmine #9400

Signed-off-by: Hunt Xu <mhuntxu@gmail.com>