### PR TITLE
metering: update external device of metering iptables rules

### DIFF
--- a/neutron/services/metering/drivers/iptables/iptables_driver.py
+++ b/neutron/services/metering/drivers/iptables/iptables_driver.py
@@ -133,15 +133,12 @@ class IptablesMeteringDriver(abstract_driver.MeteringAbstractDriver):
         if router_id in self.routers:
             del self.routers[router_id]
 
-    def get_external_device_name(self, port_id):
-        return (EXTERNAL_DEV_PREFIX + port_id)[:self.driver.DEV_NAME_LEN]
-
     def _process_metering_label_rules(self, rm, rules, label_chain,
                                       rules_chain):
         im = rm.iptables_manager
         if not rm.router['gw_port_id']:
             return
-        ext_dev = self.get_external_device_name(rm.router['gw_port_id'])
+        ext_dev = "%s+" % EXTERNAL_DEV_PREFIX
 
         for rule in rules:
             remote_ip = rule['remote_ip_prefix']


### PR DESCRIPTION
This is required by the new mechanism introduced in commit ec41bdd6f (
"l3_agent: implement EayunStack floating ip mechanism"). There will be
multiple neutron ports connected to the external network in a router
with the new mechanism. So neutron-metering iptables rules should handle
those ports of floatingips as well.

Fixes: redmine #9641

Signed-off-by: Hunt Xu <mhuntxu@gmail.com>