### PR TITLE
iptables_firewall: minor fix for _setup_metering_chains

### DIFF
--- a/neutron/agent/linux/iptables_firewall.py
+++ b/neutron/agent/linux/iptables_firewall.py
@@ -181,7 +181,7 @@ class IptablesFirewallDriver(firewall.FirewallDriver):
     def _setup_metering_chains(self, port, direction, chain_name):
         if not port['device_owner'].startswith('compute:'):
             # Only meter instances' ports
-            return '$' + chain_name
+            return chain_name
         # Only support IPv4
         chains = self._metering_chain_names(port, direction)
         for m_chain_name in chains:


### PR DESCRIPTION
Fixes: redmine #9154
Fixes: deaf40836 ("iptables_firewall: add firewall rules to meter instance
port stats")
Fixes: 9c324b301 ("iptables_firewall: use wrap chains and rules for metering)

Signed-off-by: Hunt Xu <mhuntxu@gmail.com>