### PR TITLE
metering: properly do data filtering within some APIs

### DIFF
--- a/neutron/db/metering/metering_db.py
+++ b/neutron/db/metering/metering_db.py
@@ -188,6 +188,7 @@ class MeteringDbMixin(metering.MeteringPluginBase,
                 raise metering.MeteringLabelRuleNotFound(rule_id=rule_id)
 
             context.session.delete(rule)
+        return rule
 
     def _get_metering_rules_dict(self, metering_label):
         rules = []

--- a/neutron/services/metering/metering_plugin.py
+++ b/neutron/services/metering/metering_plugin.py
@@ -42,7 +42,7 @@ class MeteringPlugin(metering_db.MeteringDbMixin,
             context, metering_label)
 
         data = metering_db.MeteringDbMixin.get_sync_data_metering(
-            self, context)
+            self, context, label['id'])
         self.meter_rpc.add_metering_label(context, data)
 
         return label
@@ -62,7 +62,7 @@ class MeteringPlugin(metering_db.MeteringDbMixin,
             context, metering_label_rule)
 
         data = metering_db.MeteringDbMixin.get_sync_data_metering(
-            self, context)
+            self, context, rule['metering_label_id'])
         self.meter_rpc.update_metering_label_rules(context, data)
 
         return rule
@@ -71,18 +71,17 @@ class MeteringPlugin(metering_db.MeteringDbMixin,
         rule = super(MeteringPlugin, self).delete_metering_label_rule(
             context, rule_id)
 
+        label_id = rule['metering_label_id']
         data = metering_db.MeteringDbMixin.get_sync_data_metering(
-            self, context)
+            self, context, label_id)
         self.meter_rpc.update_metering_label_rules(context, data)
-
-        return rule
 
     def create_es_metering_label(self, context, es_metering_label):
         label = super(MeteringPlugin, self).create_es_metering_label(
             context, es_metering_label)
 
         data = es_metering_db.EsMeteringDbMixin.get_sync_data_metering(
-            self, context)
+            self, context, label_id=label['id'])
         self.meter_rpc.add_es_metering_label(context, data)
 
         return label


### PR DESCRIPTION
This prevents getting and sending unrelated data to metering agents.

Fixes: redmine #10261

Signed-off-by: Hunt Xu <mhuntxu@gmail.com>