### PR TITLE
Loadbalancer: enable a created free port to be used by new VIP

### DIFF
--- a/neutron/extensions/loadbalancer.py
+++ b/neutron/extensions/loadbalancer.py
@@ -113,6 +113,10 @@ class ProtocolPortInUse(qexception.BadRequest):
     message = _("VIP %(vip)s has bound to the protocol port %(proto_port)s")
 
 
+class PortNotOwnedByLB(qexception.BadRequest):
+    message = _("Port %(port_id)s not owned by LOADBALANCER.")
+
+
 class PoolNotBoundToAgent(qexception.BadRequest):
     message = _("Pool %(pool)s has not bound to agent %(agent)s")
 


### PR DESCRIPTION
With this commit, when creating a new loadbalancer VIP, an exsiting free
Neutron port can be used as the VIP port.
(Port is specified using subnet_id and ip_address.)

Fixes: redmine #10286

Signed-off-by: Hunt Xu <mhuntxu@gmail.com>