### PR TITLE
Metering: use nfacct to get metering counters

### DIFF
--- a/etc/neutron/rootwrap.d/metering.filters
+++ b/etc/neutron/rootwrap.d/metering.filters
@@ -1,0 +1,12 @@
+# neutron-rootwrap command filters for nodes on which neutron is
+# expected to control network
+#
+# This file should be owned by (and only-writeable by) the root user
+
+# format seems to be
+# cmd-name: filter-name, raw-command, user, args
+
+[Filters]
+
+# metering-agent
+nfacct: CommandFilter, nfacct, root

--- a/neutron/agent/linux/nfacct.py
+++ b/neutron/agent/linux/nfacct.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2017 Eayun, Inc.
+# All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import json
+
+from neutron.agent.linux import iptables_manager
+from neutron.openstack.common import log as logging
+
+LOG = logging.getLogger(__name__)
+
+
+class NfacctMixin(object):
+    """
+    The following attributes/methods are not defined in this class:
+      * methods
+        - self.execute
+      * attributes
+        - self.root_helper
+        - self.namespace
+    """
+    NFACCT_OBJECT_NAME_LEN = 31
+
+    @staticmethod
+    def _get_nfacct_object_name(nfacct_object):
+        return nfacct_object[:NfacctMixin.NFACCT_OBJECT_NAME_LEN]
+
+    @staticmethod
+    def get_nfacct_rule_part(nfacct_object):
+        nfacct_object_name = NfacctMixin._get_nfacct_object_name(nfacct_object)
+        return "-m nfacct --nfacct-name %s" % nfacct_object_name
+
+    def _ns_wrap_cmd(self, cmd):
+        if self.namespace:
+            cmd = ['ip', 'netns', 'exec', self.namespace] + cmd
+        return cmd
+
+    def add_nfacct_objects(self, nfacct_objects):
+        args_prefix = self._ns_wrap_cmd(['nfacct', 'add'])
+        for nfacct_object in nfacct_objects:
+            nfacct_object_name = self._get_nfacct_object_name(nfacct_object)
+            args = args_prefix + [nfacct_object_name]
+            self.execute(args, root_helper=self.root_helper,
+                         check_exit_code=False)
+
+    def nfacct_flush(self):
+        args = self._ns_wrap_cmd(['nfacct', 'flush'])
+        self.execute(args, root_helper=self.root_helper, check_exit_code=False)
+
+    def parse_nfacct_output(self, nfacct_out):
+        accs = {}
+        for counter in json.loads(nfacct_out)['nfacct_counters']:
+            name = counter.pop('name')
+            accs[name] = counter
+        return accs
+
+    def get_result(self, nfacct_objects):
+        args = self._ns_wrap_cmd(['nfacct', 'list', 'reset', 'json'])
+        try:
+            nfacct_out = self.execute(args, root_helper=self.root_helper)
+        except RuntimeError:
+            return None
+
+        parsed_accs = self.parse_nfacct_output(nfacct_out)
+        ret_accs = {}
+        for nfacct_object in nfacct_objects:
+            nfacct_object_name = self._get_nfacct_object_name(nfacct_object)
+            acc = parsed_accs.get(nfacct_object_name, None)
+            if acc:
+                ret_accs[nfacct_object] = acc
+        return ret_accs
+
+
+class NfacctIptablesManager(iptables_manager.IptablesManager,
+                            NfacctMixin):
+
+    def __init__(self, *args, **kwargs):
+        super(NfacctIptablesManager, self).__init__(*args, **kwargs)
+        self.nfacct_objects = set()
+
+    def add_nfacct_object(self, object_name):
+        self.nfacct_objects.add(object_name)
+
+    def apply(self):
+        if self.iptables_apply_deferred:
+            return
+        self.add_nfacct_objects(self.nfacct_objects)
+        self.nfacct_objects = set()
+        super(NfacctIptablesManager, self).apply()
+        self.nfacct_flush()

--- a/neutron/services/metering/drivers/iptables/es_iptables_driver.py
+++ b/neutron/services/metering/drivers/iptables/es_iptables_driver.py
@@ -16,6 +16,7 @@
 import six
 
 from neutron.agent.linux import iptables_manager
+from neutton.agent.linux.nfacct import NfacctMixin
 from neutron.common import constants as constants
 from neutron.common import log
 from neutron.openstack.common import log as logging
@@ -104,7 +105,7 @@ class EsIptablesMeteringDriver(iptables_driver.IptablesMeteringDriver):
                 self._process_associate_es_metering_label(router)
 
     @staticmethod
-    def _get_es_meter_rule(label, label_chain):
+    def _get_es_meter_rule(label):
         rule_parts = []
         if label['direction'] == 'ingress':
             rule_parts += ['-m mark --mark %s' % ES_METERING_MARK]
@@ -121,38 +122,31 @@ class EsIptablesMeteringDriver(iptables_driver.IptablesMeteringDriver):
         if label['tcp_port'] is not None:
             rule_parts += ['-p tcp %s %s' % (port_selector, label['tcp_port'])]
 
-        rule_parts += ['-j %s' % label_chain]
+        rule_parts += [NfacctMixin.get_nfacct_rule_part(label['id'])]
 
         return ' '.join(rule_parts)
 
-    @staticmethod
-    def _get_label_chain_name(label_id):
-        return iptables_manager.get_chain_name(
-            iptables_driver.WRAP_NAME + iptables_driver.LABEL + label_id,
-            wrap=False)
-
     def _add_es_metering_label(self, rm, label):
         table = rm.iptables_manager.ipv4['mangle']
-        label_id = label['id']
-        label_chain = self._get_label_chain_name(label_id)
-        table.add_chain(label_chain, wrap=False)
-        es_meter_rule = self._get_es_meter_rule(label, label_chain)
+        rm.iptables_manager.add_nfacct_object(label['id'])
+        es_meter_rule = self._get_es_meter_rule(label)
         table.add_rule('POSTROUTING', es_meter_rule)
         if label['internal_ip'] is None and label['direction'] == 'ingress':
             # If internal IP is unspecified, we should also count traffic
             # directed to the router itself.
             table.add_rule('INPUT', es_meter_rule)
-        table.add_rule(label_chain, '', wrap=False)
-        rm.es_metering_labels[label_id] = label
+        rm.es_metering_labels[label['id']] = label
 
     def _remove_es_metering_label(self, rm, label_id):
         table = rm.iptables_manager.ipv4['mangle']
-        if label_id not in rm.es_metering_labels:
+        label = rm.es_metering_labels.pop(label_id, None)
+        if label is None:
             return
-        label_chain = self._get_label_chain_name(label_id)
-        table.remove_chain(label_chain, wrap=False)
 
-        del rm.es_metering_labels[label_id]
+        es_meter_rule = self._get_es_meter_rule(label)
+        table.remove_rule('POSTROUTING', es_meter_rule)
+        if label['internal_ip'] is None and label['direction'] == 'ingress':
+            table.remove_rule('INPUT', es_meter_rule)
 
     def _process_associate_es_metering_label(self, router):
         self._update_router(router)


### PR DESCRIPTION
Using nfacct can speed up the process of getting traffic counters by
getting counters in the same router at once.

Use eventlet to parallelize the procedures of getting traffic counters
among lots of routers.

Fixes: redmine #10878

Signed-off-by: Hunt Xu <mhuntxu@gmail.com>