### PR TITLE
Another fixup for redline-10878

### DIFF
--- a/neutron/services/metering/drivers/iptables/es_iptables_driver.py
+++ b/neutron/services/metering/drivers/iptables/es_iptables_driver.py
@@ -47,8 +47,8 @@ class EsRouterWithMetering(iptables_driver.RouterWithMetering):
             iptables_driver.EXTERNAL_DEV_PREFIX, ES_METERING_MARK)
         im.ipv4['mangle'].add_rule('PREROUTING', mark_rule)
 
-    def iter_metering_labels(self):
-        return self.metering_labels.items() + self.es_metering_labels.items()
+    def get_metering_labels(self):
+        return self.metering_labels.keys() + self.es_metering_labels.keys()
 
 
 class EsIptablesMeteringDriver(iptables_driver.IptablesMeteringDriver):

--- a/neutron/services/metering/drivers/iptables/iptables_driver.py
+++ b/neutron/services/metering/drivers/iptables/iptables_driver.py
@@ -81,8 +81,8 @@ class RouterWithMetering(object):
             use_ipv6=ipv6_utils.is_enabled())
         self.metering_labels = {}
 
-    def iter_metering_labels(self):
-        return self.metering_labels.items()
+    def get_metering_labels(self):
+        return self.metering_labels.keys()
 
 
 class IptablesMeteringDriver(abstract_driver.MeteringAbstractDriver):
@@ -250,7 +250,7 @@ class IptablesMeteringDriver(abstract_driver.MeteringAbstractDriver):
         if not rm:
             return (True, router_id, {})
 
-        label_ids = rm.metering_labels.keys()
+        label_ids = rm.get_metering_labels()
         accs = rm.iptables_manager.get_result(label_ids)
         if accs is None:
             return (False, router_id, {})


### PR DESCRIPTION
metering: correctly get label ids when getting traffic counters

Es-metering use different attribute for metering labels.

Signed-off-by: Hunt Xu <mhuntxu@gmail.com>