### PR TITLE
Count metering label only once

### DIFF
--- a/neutron/services/metering/drivers/iptables/iptables_driver.py
+++ b/neutron/services/metering/drivers/iptables/iptables_driver.py
@@ -276,6 +276,11 @@ class IptablesMeteringDriver(abstract_driver.MeteringAbstractDriver):
                                 'router: %s'), router_id)
             for label_id, label_acc in acc.items():
                 acc = accs.get(label_id, {'pkts': 0, 'bytes': 0})
+                # Hack for kernel without nfacct per netns support.
+                # Kernel commit 3499abb249bb5ed9d21031944bc3059ec4aa2909
+                # Count metering label only once.
+                if acc['pkts'] != 0 or acc['bytes'] != 0:
+                    continue
                 acc['pkts'] += label_acc['pkts']
                 acc['bytes'] += label_acc['bytes']
                 accs[label_id] = acc


### PR DESCRIPTION
This is a hack for kernel which doesn't support nfacct per net
namespace. Upstream commit 3499abb249bb5ed9d21031944bc3059ec4aa2909.

Fixes: redmine #10957

Signed-off-by: Hunt Xu <mhuntxu@gmail.com>