### PR TITLE
metering: fix problem when loading driver

### DIFF
--- a/neutron/services/metering/agents/metering_agent.py
+++ b/neutron/services/metering/agents/metering_agent.py
@@ -75,8 +75,8 @@ class MeteringAgent(MeteringPluginRpc, manager.Manager):
 
     def __init__(self, host, conf=None):
         self.conf = conf or cfg.CONF
-        self._load_drivers()
         self.root_helper = config.get_root_helper(self.conf)
+        self._load_drivers()
         self.context = context.get_admin_context_without_session()
         self.metering_loop = loopingcall.FixedIntervalLoopingCall(
             self._metering_loop


### PR DESCRIPTION
Driver needs agent's root_helper.

Fixes: 7cd1a7d3856 ("metering: fix error initializing dummy iptables
manager in driver")

Signed-off-by: Hunt Xu <mhuntxu@gmail.com>