### PR TITLE
metering: exclude label without rules when getting counters

### DIFF
--- a/neutron/services/metering/drivers/iptables/es_iptables_driver.py
+++ b/neutron/services/metering/drivers/iptables/es_iptables_driver.py
@@ -50,7 +50,9 @@ class EsRouterWithMetering(iptables_driver.RouterWithMetering):
         im.ipv4['mangle'].add_rule('PREROUTING', mark_rule)
 
     def get_metering_labels(self):
-        return self.metering_labels.keys() + self.es_metering_labels.keys()
+        return super(
+            EsRouterWithMetering, self
+        ).get_metering_labels() + self.es_metering_labels.keys()
 
 
 class EsIptablesMeteringDriver(iptables_driver.IptablesMeteringDriver):

--- a/neutron/services/metering/drivers/iptables/iptables_driver.py
+++ b/neutron/services/metering/drivers/iptables/iptables_driver.py
@@ -82,7 +82,9 @@ class RouterWithMetering(object):
         self.metering_labels = {}
 
     def get_metering_labels(self):
-        return self.metering_labels.keys()
+        return [
+            label_id for label_id in self.metering_labels.keys()
+            if self.metering_labels[label_id]['rules']]
 
 
 class IptablesMeteringDriver(abstract_driver.MeteringAbstractDriver):
@@ -249,6 +251,7 @@ class IptablesMeteringDriver(abstract_driver.MeteringAbstractDriver):
                     self._process_metering_label_rules(rm, rules,
                                                        label_id,
                                                        rules_chain)
+                rm.metering_labels[label_id] = label
 
     @log.log
     def remove_metering_label(self, context, routers):


### PR DESCRIPTION
With nfacct we use "nfacct flush" to clean up unused objects. Thus a
label without rules will lead to unused objects which will be purged
later. And this leads to errors when getting counters for this label
because the related object is missing.

Fixes: redmine #10988

Signed-off-by: Hunt Xu <mhuntxu@gmail.com>