### PR TITLE
db: fix backref cascade between router and es_meter_label

### DIFF
--- a/neutron/db/metering/es_metering_db.py
+++ b/neutron/db/metering/es_metering_db.py
@@ -45,7 +45,8 @@ class EsMeteringLabel(model_base.BASEV2, models_v2.HasId, models_v2.HasTenant):
     tcp_port = sa.Column(sa.Integer)
     router = orm.relationship(
         Router,
-        backref=orm.backref("es_metering_labels", lazy='joined', uselist=True)
+        backref=orm.backref("es_metering_labels", lazy='joined', uselist=True,
+                            cascade='all, delete-orphan')
     )
 
 


### PR DESCRIPTION
Fixes: redmine #11042

Signed-off-by: Hunt Xu <mhuntxu@gmail.com>