### PR TITLE
Do not restart vpn processes for every router update

### DIFF
--- a/neutron/services/vpn/device_drivers/ipsec.py
+++ b/neutron/services/vpn/device_drivers/ipsec.py
@@ -542,7 +542,8 @@ class IPsecDriver(device_drivers.DeviceDriver):
         when vpnservices updated.
         Then this method start sync with server.
         """
-        self.sync(context, [])
+        router = kwargs.get('router')
+        self.sync(context, [router] if router else [])
 
     @abc.abstractmethod
     def create_process(self, process_id, vpnservice, namespace):
@@ -679,30 +680,41 @@ class IPsecDriver(device_drivers.DeviceDriver):
         vpnservices = self.agent_rpc.get_vpn_services_on_host(
             context, self.host)
         router_ids = [vpnservice['router_id'] for vpnservice in vpnservices]
-        # Ensure the ipsec process is enabled
-        for vpnservice in vpnservices:
-            process = self.ensure_process(vpnservice['router_id'],
-                                          vpnservice=vpnservice)
-            self._update_nat(vpnservice, self.agent.add_nat_rule)
-            process.update()
+        sync_router_ids = [router['id'] for router in routers]
 
+        self._sync_vpn_processes(vpnservices, sync_router_ids)
+        self._delete_vpn_processes(sync_router_ids, router_ids)
+        self._cleanup_stale_vpn_processes(router_ids)
+
+        self.report_status(context)
+
+    def _sync_vpn_processes(self, vpnservices, sync_router_ids):
+        # Ensure the ipsec process is enabled only for
+        # - the vpn services which are not yet in self.processes
+        # - vpn services whose router id is in 'sync_router_ids'
+        for vpnservice in vpnservices:
+            if vpnservice['router_id'] not in self.processes or (
+                    vpnservice['router_id'] in sync_router_ids):
+                process = self.ensure_process(vpnservice['router_id'],
+                                              vpnservice=vpnservice)
+                self._update_nat(vpnservice, self.agent.add_nat_rule)
+                process.update()
+
+    def _delete_vpn_processes(self, sync_router_ids, vpn_router_ids):
         # Delete any IPSec processes that are
         # associated with routers, but are not running the VPN service.
-        for router in routers:
-            #We are using router id as process_id
-            process_id = router['id']
-            if process_id not in router_ids:
-                process = self.ensure_process(process_id)
+        for process_id in sync_router_ids:
+            if process_id not in vpn_router_ids:
+                self.ensure_process(process_id)
                 self.destroy_router(process_id)
 
+    def _cleanup_stale_vpn_processes(self, vpn_router_ids):
         # Delete any IPSec processes running
         # VPN that do not have an associated router.
-        process_ids = [process_id
-                       for process_id in self.processes
-                       if process_id not in router_ids]
+        process_ids = [pid for pid in self.processes
+                       if pid not in vpn_router_ids]
         for process_id in process_ids:
             self.destroy_router(process_id)
-        self.report_status(context)
 
 
 class OpenSwanDriver(IPsecDriver):

--- a/neutron/services/vpn/service_drivers/__init__.py
+++ b/neutron/services/vpn/service_drivers/__init__.py
@@ -102,5 +102,6 @@ class BaseIPsecVpnAgentApi(n_rpc.RpcProxy):
 
     def vpnservice_updated(self, context, router_id, **kwargs):
         """Send update event of vpnservices."""
+        kwargs['router'] = {'id': router_id}
         self._agent_notification(context, 'vpnservice_updated', router_id,
                                  **kwargs)


### PR DESCRIPTION
Presently all the vpn processes are restarted when any
router is updated, even if the updated router do not
host any vpn services. 'device_drivers.ipsec.sync()'
updates all the vpn services which results in stopping
and then starting of the vpn processes.
This patch addresses the issue by
1. Passing router id information to the vpnservice_updated
2. (Re)starting the vpn process only if the
      - the vpn service is newly added or
      - the agent has been restarted before the sync or
      - the sync has the router id of the vpn service

This patch is from upstream neutron-vpnaas commit ae02852296f.

Upstram-bug: https://bugs.launchpad.net/neutron/+bug/1393589
Fixes: redmine #11129

Signed-off-by: Hunt Xu <mhuntxu@gmail.com>